### PR TITLE
Option to split output into yearly or monthly files

### DIFF
--- a/classification/classification.py
+++ b/classification/classification.py
@@ -1,7 +1,9 @@
 import argparse
 import os
 import time
+import xbt.common
 from classification import experiment
+
 
 def _get_arguments(description):
     parser = argparse.ArgumentParser(description=description)
@@ -13,10 +15,16 @@ def _get_arguments(description):
                 'written to this location.')
     parser.add_argument('--input-path', dest='input_path', help=help_msg)
     help_msg = 'The path to the directory containing files to be preprocessed, typically netCDF files from WOD or similar source.'
-    parser.add_argument('--output-path', dest='output_path', help=help_msg)
     parser.add_argument('--preproc-path', dest='preproc_path', help=help_msg, default=None)
     help_msg = 'The path to the directory for experimenting output. A subdirectory will be created using the experiment name.'
-    
+    parser.add_argument('--output-path', dest='output_path', help=help_msg)
+    help_msg = 'Specify whether classification output should be in a single file, or split by year or month.'
+    parser.add_argument('--output-file-split', 
+                        dest='output_file_split', 
+                        help=help_msg, 
+                        choices=xbt.common.OUTPUT_FREQS,
+                        default = xbt.common.OUTPUT_SINGLE,
+                       )
     return parser.parse_args()
 
 def experiment_timer(exp_func):
@@ -41,6 +49,7 @@ def run_single_experiment():
                                                          exp_args.input_path, 
                                                          exp_args.output_path,
                                                   preproc_dir=exp_args.preproc_path,
+                                                  output_split=exp_args.output_file_split,
                                                  )
     try:
         xbt_exp.run_single_experiment()
@@ -63,6 +72,7 @@ def run_cv_experiment():
                                                          exp_args.input_path, 
                                                          exp_args.output_path,
                                                   preproc_dir=exp_args.preproc_path,
+                                                  output_split=exp_args.output_file_split,
                                                  )
     try:
         xbt_exp.run_cv_experiment()
@@ -86,6 +96,7 @@ def run_cvhpt_experiment():
                                                          exp_args.input_path, 
                                                          exp_args.output_path,
                                                   preproc_dir=exp_args.preproc_path,
+                                                  output_split=exp_args.output_file_split,
                                                  )
     try:
         xbt_exp.run_cvhpt_experiment()
@@ -107,6 +118,7 @@ def run_inference():
                                                   exp_args.input_path, 
                                                   exp_args.output_path,
                                                   preproc_dir=exp_args.preproc_path,
+                                                  output_split=exp_args.output_file_split,
                                                  )
     try:
         xbt_exp.run_inference()

--- a/classification/experiment.py
+++ b/classification/experiment.py
@@ -22,7 +22,7 @@ from classification.imeta import imeta_classification, XBT_MAX_DEPTH
 
 RESULT_FNAME_TEMPLATE = 'xbt_metrics_{name}.csv'
 SCORE_FNAME_TEMPLATE = 'xbt_score_{name}.csv'
-OUTPUT_FNAME_TEMPLATE = 'xbt_classifications_{name}.csv'
+OUTPUT_FNAME_TEMPLATE = 'xbt_classifications_{exp_name}_{subset}.csv'
 CLASSIFIER_EXPORT_FNAME_TEMPLATE = 'xbt_classifier_{exp}_{split_num}.joblib'
 
 UNSEEN_FOLD_NAME = 'unseen_fold'
@@ -34,6 +34,7 @@ OUTPUT_CQ_FLAG = 'classification_quality_flag_{var_name}'
 OUTPUT_CQ_INPUT = 0
 OUTPUT_CQ_ML = 1
 OUTPUT_CQ_IMETA = 2
+
 
 class NumpyEncoder(json.JSONEncoder):
     """Encoder to print the result of tuning into a json file"""
@@ -50,10 +51,11 @@ class ClassificationExperiment(object):
     """
     Class designed for implementing features engineering, design of the input space, algorithms fine tuning and delivering outut prediction
     """
-    def __init__(self, json_descriptor, data_dir, output_dir, preproc_dir=None):
+    def __init__(self, json_descriptor, data_dir, output_dir, output_split, preproc_dir=None):
         # assign arguments
         self.data_dir = data_dir
         self.root_output_dir = output_dir
+        self.output_split = output_split
         self.preproc_dir = preproc_dir
         self.json_descriptor = json_descriptor
         
@@ -160,12 +162,13 @@ class ClassificationExperiment(object):
         print(f'{duration1:.3f} seconds since start.')
         if write_predictions:
             out_name = self.experiment_name + '_cv_' + self._exp_datestamp
-            out_path = os.path.join(self.exp_output_dir, OUTPUT_FNAME_TEMPLATE.format(name=out_name))
-            print(f'output predictions to {out_path}')
             self.dataset.output_data(
-                os.path.join(self.exp_output_dir, 
-                             OUTPUT_FNAME_TEMPLATE.format(name=out_name)),
-                target_features=[feature_name])
+                self.exp_output_dir,
+                fname_template=OUTPUT_FNAME_TEMPLATE,
+                exp_name=out_name,
+                output_split=self.output_split,
+                target_features=[feature_name],
+            )
             
         if export_classifiers:
             print('exporting classifier objects through pickle')
@@ -308,12 +311,13 @@ class ClassificationExperiment(object):
         print('output predictions')
         if write_predictions:
             out_name = self.experiment_name + '_cv_' + self._exp_datestamp
-            out_path = os.path.join(self.exp_output_dir, OUTPUT_FNAME_TEMPLATE.format(name=out_name))
-            print(f'output predictions to {out_path}')
             self.dataset.output_data(
-                os.path.join(self.exp_output_dir, 
-                             OUTPUT_FNAME_TEMPLATE.format(name=out_name)),
-                target_features=[])
+                self.exp_output_dir,
+                fname_template=OUTPUT_FNAME_TEMPLATE,
+                exp_name=out_name,
+                output_split=self.output_split,
+                target_features=[],
+            )
                     
         if export_classifiers:
             print('exporting classifier objects through pickle')
@@ -385,12 +389,13 @@ class ClassificationExperiment(object):
         
         if write_predictions:
             out_name = self.experiment_name + '_cv_' + self._exp_datestamp
-            out_path = os.path.join(self.exp_output_dir, OUTPUT_FNAME_TEMPLATE.format(name=out_name))
-            print(f'output predictions to {out_path}')
             self.dataset.output_data(
-                os.path.join(self.exp_output_dir, 
-                             OUTPUT_FNAME_TEMPLATE.format(name=out_name)),
-                target_features=[])
+                self.exp_output_dir,
+                fname_template=OUTPUT_FNAME_TEMPLATE,
+                exp_name=out_name,
+                output_split=self.output_split,
+                target_features=[],
+            )
                     
         return self.classifiers
     

--- a/xbt/common.py
+++ b/xbt/common.py
@@ -1,5 +1,11 @@
 import datetime
 
+# flags for specifying how many files to split output over
+OUTPUT_SINGLE = 'single' # all output in one file
+OUTPUT_YEARLY = 'yearly' # output divided into files for each year
+OUTPUT_MONTHLY = 'monthly' # output divided into files for each month
+OUTPUT_FREQS = [OUTPUT_SINGLE, OUTPUT_YEARLY, OUTPUT_MONTHLY]
+
 DATESTAMP_TEMPLATE = '{dt.year:04d}{dt.month:02d}{dt.day:02d}_{dt.hour:02d}{dt.minute:02d}'
 
 def generate_datestamp():


### PR DESCRIPTION
previously, output classification for the whole dataset were output as a single CSV file. The datasets that this data feeds into generally have data split up by year or month, so we need an option for the XBT output data to be similarly split. This PR adds this option, with a `--output-file-split` option which can be single, monthly or yearly. I have also updated the documentation on the wiki to reflect this.

Closes #62 .